### PR TITLE
returning valid result now

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target
+.idea

--- a/ngls/src/engine/mod.rs
+++ b/ngls/src/engine/mod.rs
@@ -1,3 +1,4 @@
+use std::path::Path;
 use std::{collections::HashSet, fs};
 use regex::Regex;
 use libc::{closedir, dirent, opendir, readdir};
@@ -22,11 +23,16 @@ pub fn search_function(path: String, keyword: String)-> Result{
     //iterate over hashset
     for file_path in contents{
         //open every found file
+        let file_path_str = file_path.clone();
+        let path = Path::new(file_path_str.as_str());
+        let file_size = path.metadata().unwrap().len();
         if let Ok(result) =  fs::read_to_string(file_path.clone()) {
             if result.contains(&keyword){
                 for lines in result.lines(){
                     //return relevant file
-                    return Result::new(file_path, 0, lines.to_string(), Filesize::KiB);
+                    if lines.contains(&keyword){
+                        return Result::new(file_path, file_size, lines.to_string(), Filesize::KiB);
+                    }
                 }
             }
         } else{

--- a/ngls/src/results/mod.rs
+++ b/ngls/src/results/mod.rs
@@ -9,7 +9,7 @@ pub enum Filesize{
 #[derive(Default, Debug)]
 pub struct Result{
     path: String,
-    size: i32,
+    size: u64,
     line: String,
     filesize_unit: Filesize,
 }
@@ -17,7 +17,7 @@ pub struct Result{
 
 
 impl Result{
-    pub fn new(path: String, size: i32, line: String, filesize_unit: Filesize) -> Result{
+    pub fn new(path: String, size: u64, line: String, filesize_unit: Filesize) -> Result{
         Result { path, size, line, filesize_unit }
     }
 
@@ -28,11 +28,11 @@ impl Result{
                 self.filesize_unit = Filesize::KiB
             }
             "MiB" => {
-                self.size = self.size / i32::pow(1024, 2); 
+                self.size = self.size / u64::pow(1024, 2); 
                 self.filesize_unit = Filesize::MiB
             }
             "GiB" => {
-                self.size = self.size / i32::pow(1024, 3); 
+                self.size = self.size / u64::pow(1024, 3); 
                 self.filesize_unit = Filesize::GiB
             }
             _ => ()


### PR DESCRIPTION
Added reading the filesize through rusts Path system.
Changed return value to u64 to match the return of the `.len()` function.